### PR TITLE
[Fix] Class renamed to Blinkist::AirbrakeScrubber

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,12 +82,14 @@ workflows:
   build-and-deploy:
     jobs:
       - build
+        filters:
+          tags:
+            only: /.*/
       - deploy:
         requires:
           - build
         filters:
           tags:
-            only: /.*/
+            only: /^v.*/
           branches:
-            only:
-              - master
+            ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ workflows:
   version: 2
   build-and-deploy:
     jobs:
-      - build
+      - build:
         filters:
           tags:
             only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ workflows:
     jobs:
       - build:
         filters:
-          branches:
+          tags:
             only: /.*/
       - deploy:
         requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ workflows:
     jobs:
       - build:
         filters:
-          tags:
+          branches:
             only: /.*/
       - deploy:
         requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
             gem build blinkist-airbrake-scrubber.gemspec
             gem push "blinkist-airbrake-scrubber-$(git describe --tags | cut -c2-).gem"
 
+
 workflows:
   version: 2
   build-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,4 +89,5 @@ workflows:
           tags:
             only: /.*/
           branches:
-            ignore: /.*/
+            only:
+              - master

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Blinkist::Airbrake::Scrubber
+# Blinkist::AirbrakeScrubber
 
-Blinkist::Airbrake::Scrubber provides an Airbrake scrubbing service to remove various sensitive informations from the notifications, e.g. emails. It does *not* replace Airbrake configuration, but provides some seamless functionality.
+Blinkist::AirbrakeScrubber provides an Airbrake scrubbing service to remove various sensitive informations from the notifications, e.g. emails. It does *not* replace Airbrake configuration, but provides some seamless functionality.
 
 ## Installation
 
@@ -19,7 +19,7 @@ And then execute:
 To extend the functionality, create a new scrubber file in `lib/blinkist-airbrake-scrubber/scrubbers` folder, like the template:
 
 ```ruby
-module Blinkist::Airbrake::Scrubber
+module Blinkist::AirbrakeScrubber
   class WubbaLubba
     REGEXP = /[\S]+@[\S]+/i
 
@@ -34,7 +34,7 @@ module Blinkist::Airbrake::Scrubber
 end
 ```
 
-Then, add the class to Blinkist::Airbrake::Scrubber's SCRUBBERS list to have it ran after Airbrake.configure
+Then, add the class to Blinkist::AirbrakeScrubber's SCRUBBERS list to have it ran after Airbrake.configure
 
 ### Applications using this gem
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Blinkist::AirbrakeScrubber provides an Airbrake scrubbing service to remove vari
 
 Add this line to your application's Gemfile:
 
-    gem "blinkist-airbrake-scrubber", "0.0.1", github: "blinkist-airbrake-scrubber", tag: "v0.0.1"
+    gem "blinkist-airbrake-scrubber"
 
 And then execute:
 
@@ -36,15 +36,9 @@ end
 
 Then, add the class to Blinkist::AirbrakeScrubber's SCRUBBERS list to have it ran after Airbrake.configure
 
-### Applications using this gem
-
-There are a few applications available on GitHub that use this gem. For usage see:
-
-* blinkist-messenger
-
 ### Dependencies
 
-This gem has dependency on airbrake (~> 5), it will automatically add it unless already bundled.
+This gem has dependency on airbrake (~> 7), it will automatically add it unless already bundled.
 
 ## Maintainers
 

--- a/blinkist-airbrake-scrubber.gemspec
+++ b/blinkist-airbrake-scrubber.gemspec
@@ -5,12 +5,12 @@ require_relative "lib/blinkist-airbrake-scrubber/version"
 
 Gem::Specification.new do |gem|
   gem.name          = "blinkist-airbrake-scrubber"
-  gem.version       = Blinkist::Airbrake::Scrubber::VERSION
-  gem.authors       = ["Paweł Komarnicki", "Dinesh Vasudevan"]
-  gem.email         = ["pawel@blinkist.com", "dinesh@blinkist.com"]
+  gem.version       = Blinkist::AirbrakeScrubber::VERSION
+  gem.authors       = ["Paweł Komarnicki", "Dinesh Vasudevan", 'Tomek Przedmojski']
+  gem.email         = ["pawel@blinkist.com", "dinesh@blinkist.com", "tomek@blinkist.com"]
   gem.description   = %q{Email scrubbing configuration for Airbrake at Blinkist}
   gem.summary       = %q{With this, Airbrake will not leak emails via exception notifications}
-  gem.homepage      = "https://github.com/blinkist/blinkist-airbrake-scrubber"
+  gem.homepage      = "https://github.com/blinkist/airbrake-scrubber"
   gem.license       = "MIT"
 
   # Airbrake

--- a/lib/blinkist-airbrake-scrubber.rb
+++ b/lib/blinkist-airbrake-scrubber.rb
@@ -4,32 +4,30 @@ Dir[File.expand_path('../../lib/**/*.rb', __FILE__)].each do |f|
 end
 
 # Prepend the original Airbrake module
-# Note: Do not remove from this file, it needs to be before Blinkist::Airbrake::Scrubber
+# Note: Do not remove from this file, it needs to be before Blinkist::AirbrakeScrubber
 module Airbrake
   class << self
-    prepend Blinkist::Airbrake::Scrubber
+    prepend Blinkist::AirbrakeScrubber
   end
 end
 
 # Set up the namespace and run every scrubber listed in SCRUBBERS
 module Blinkist
-  module Airbrake
-    module Scrubber
-      FILTERED  = '[Filtered]'
-      SCRUBBERS = [ MessageEmail, ParamsEmail, ParamsPassword ]
+  module AirbrakeScrubber
+    FILTERED  = '[Filtered]'
+    SCRUBBERS = [ MessageEmail, ParamsEmail, ParamsPassword ]
 
-      # Override original Airbrake.configure
-      def configure(*args, &block)
-        super
-      ensure
-        Blinkist::Airbrake::Scrubber.run!
-      end
-
-      # Run scrubbers
-      def self.run!
-        SCRUBBERS.each { |scrubber| scrubber::scrub! }
-      end
-
+    # Override original Airbrake.configure
+    def configure(*args, &block)
+      super
+    ensure
+      Blinkist::AirbrakeScrubber.run!
     end
+
+    # Run scrubbers
+    def self.run!
+      SCRUBBERS.each { |scrubber| scrubber::scrub! }
+    end
+
   end
 end

--- a/lib/blinkist-airbrake-scrubber/deep_traversal.rb
+++ b/lib/blinkist-airbrake-scrubber/deep_traversal.rb
@@ -1,43 +1,41 @@
 # DeepTraversal provides traverse possibility of Hashes
 # Can handle Hash objects with deep nesting, or other nested objects that can be dug deeper (e.g. Array)
 module Blinkist
-  module Airbrake
-    module Scrubber
+  module AirbrakeScrubber
 
-      class DeepTraversal
-        def initialize(source)
-          @source = source
-        end
-
-        def traverse(&block)
-          recursive_traverse(@source, &block)
-        end
-
-        private
-
-        def recursive_traverse(input, &block)
-          case input
-          when Array
-            input.map { |i| recursive_traverse(i, &block) }
-
-          when Hash
-            Hash[input.map { |key, value|
-
-              # Go deeper for things that are not simple objects
-              case value
-              when Array, Hash
-                [ key, recursive_traverse(value, &block) ]
-              else
-                [ key, block.call(key, value) ]
-              end
-
-            }]
-          else
-            input
-          end
-        end
+    class DeepTraversal
+      def initialize(source)
+        @source = source
       end
 
+      def traverse(&block)
+        recursive_traverse(@source, &block)
+      end
+
+      private
+
+      def recursive_traverse(input, &block)
+        case input
+        when Array
+          input.map { |i| recursive_traverse(i, &block) }
+
+        when Hash
+          Hash[input.map { |key, value|
+
+            # Go deeper for things that are not simple objects
+            case value
+            when Array, Hash
+              [ key, recursive_traverse(value, &block) ]
+            else
+              [ key, block.call(key, value) ]
+            end
+
+          }]
+        else
+          input
+        end
+      end
     end
+
   end
 end

--- a/lib/blinkist-airbrake-scrubber/scrubbers/message_email.rb
+++ b/lib/blinkist-airbrake-scrubber/scrubbers/message_email.rb
@@ -1,21 +1,19 @@
 module Blinkist
-  module Airbrake
-    module Scrubber
-      class MessageEmail
-        REGEXP = /[\S]+@[\S]+/i
+  module AirbrakeScrubber
+    class MessageEmail
+      REGEXP = /[\S]+@[\S]+/i
 
-        def self.scrub!
-          ::Airbrake.add_filter do |notice|
-            # Cannot do gsub! coz of frozen literals
-            notice[:errors].each { |error| error[:message] = scrub(error[:message]) }
-          end
-        end # def self.scrub!
-
-        def self.scrub(message)
-          message.gsub(REGEXP, FILTERED)
+      def self.scrub!
+        ::Airbrake.add_filter do |notice|
+          # Cannot do gsub! coz of frozen literals
+          notice[:errors].each { |error| error[:message] = scrub(error[:message]) }
         end
+      end # def self.scrub!
 
+      def self.scrub(message)
+        message.gsub(REGEXP, FILTERED)
       end
+
     end
   end
 end

--- a/lib/blinkist-airbrake-scrubber/scrubbers/params_email.rb
+++ b/lib/blinkist-airbrake-scrubber/scrubbers/params_email.rb
@@ -1,19 +1,17 @@
 module Blinkist
-  module Airbrake
-    module Scrubber
-      class ParamsEmail
+  module AirbrakeScrubber
+    class ParamsEmail
 
-        def self.scrub!
-          ::Airbrake.add_filter do |notice|
-            notice[:params] = DeepTraversal.new(notice[:params]).traverse do |key, value|
-              value = FILTERED if key.to_s == 'email'
-              value
-            end
-            notice
+      def self.scrub!
+        ::Airbrake.add_filter do |notice|
+          notice[:params] = DeepTraversal.new(notice[:params]).traverse do |key, value|
+            value = FILTERED if key.to_s == 'email'
+            value
           end
-        end # def self.scrub!
+          notice
+        end
+      end # def self.scrub!
 
-      end
     end
   end
 end

--- a/lib/blinkist-airbrake-scrubber/scrubbers/params_password.rb
+++ b/lib/blinkist-airbrake-scrubber/scrubbers/params_password.rb
@@ -1,19 +1,17 @@
 module Blinkist
-  module Airbrake
-    module Scrubber
-      class ParamsPassword
+  module AirbrakeScrubber
+    class ParamsPassword
 
-        def self.scrub!
-          ::Airbrake.add_filter do |notice|
-            notice[:params] = DeepTraversal.new(notice[:params]).traverse do |key, value|
-              value = FILTERED if key.to_s == 'password'
-              value
-            end
-            notice
+      def self.scrub!
+        ::Airbrake.add_filter do |notice|
+          notice[:params] = DeepTraversal.new(notice[:params]).traverse do |key, value|
+            value = FILTERED if key.to_s == 'password'
+            value
           end
-        end # def self.scrub!
+          notice
+        end
+      end # def self.scrub!
 
-      end
     end
   end
 end

--- a/lib/blinkist-airbrake-scrubber/version.rb
+++ b/lib/blinkist-airbrake-scrubber/version.rb
@@ -1,7 +1,7 @@
 module Blinkist
-  module Airbrake
-    module Scrubber
-      VERSION = "2.1.2"
-    end
+  module AirbrakeScrubber
+
+    VERSION = "2.1.2"
+    
   end
 end

--- a/spec/specs/lib/blinkist-airbrake-scrubber/airbrake_spec.rb
+++ b/spec/specs/lib/blinkist-airbrake-scrubber/airbrake_spec.rb
@@ -10,14 +10,14 @@ describe Airbrake do
   }
 
   describe "Module#prepend" do
-    it "does have Blinkist::Airbrake::Scrubber as one of the ancestors" do
-      expect(described_class.ancestors).to include(Blinkist::Airbrake::Scrubber)
+    it "does have Blinkist::AirbrakeScrubber as one of the ancestors" do
+      expect(described_class.ancestors).to include(Blinkist::AirbrakeScrubber)
     end
   end
 
   describe '.configure' do
-    it "does call Blinkist::Airbrake::Scrubber.configure" do
-      expect_any_instance_of(Blinkist::Airbrake::Scrubber).to receive(:configure)
+    it "does call Blinkist::AirbrakeScrubber.configure" do
+      expect_any_instance_of(Blinkist::AirbrakeScrubber).to receive(:configure)
       instantiate_airbrake
     end
   end

--- a/spec/specs/lib/blinkist-airbrake-scrubber/deep_traversal_spec.rb
+++ b/spec/specs/lib/blinkist-airbrake-scrubber/deep_traversal_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'blinkist-airbrake-scrubber'
 
-describe Blinkist::Airbrake::Scrubber::DeepTraversal do
+describe Blinkist::AirbrakeScrubber::DeepTraversal do
   subject { described_class.new(source) }
 
   let(:source) { Hash.new }

--- a/spec/specs/lib/blinkist-airbrake-scrubber/scrubbers/message_email_spec.rb
+++ b/spec/specs/lib/blinkist-airbrake-scrubber/scrubbers/message_email_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Blinkist::Airbrake::Scrubber::MessageEmail do
+describe Blinkist::AirbrakeScrubber::MessageEmail do
 
   describe "Structure" do
     it "has REGEXP constant" do
@@ -24,7 +24,7 @@ describe Blinkist::Airbrake::Scrubber::MessageEmail do
   # It's ridiculously hard to peek into Airbrake::Notice
   # Instead verify the functionality here
   describe ".scrub" do
-    let(:filtered)  { Blinkist::Airbrake::Scrubber::FILTERED }
+    let(:filtered)  { Blinkist::AirbrakeScrubber::FILTERED }
     let(:regexp)    { described_class::REGEXP }
 
     let(:valid_domains) { %w{ example.org exam-ple.org exam.ple.org e-xam.ple.org e-xam.p-le.org e.x.a.m.p.l.e.co.uk } }

--- a/spec/specs/lib/blinkist-airbrake-scrubber/scrubbers/params_email_spec.rb
+++ b/spec/specs/lib/blinkist-airbrake-scrubber/scrubbers/params_email_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Blinkist::Airbrake::Scrubber::ParamsEmail do
+describe Blinkist::AirbrakeScrubber::ParamsEmail do
   let(:notifier) { Airbrake[:default] }
   let(:notice) {
     Airbrake[:default].build_notice(
@@ -23,7 +23,7 @@ describe Blinkist::Airbrake::Scrubber::ParamsEmail do
 
     it "scrubs the email from the params hash" do
       notifier.instance_variable_get(:@filter_chain).refine(notice)
-      expect(notice[:params][:email]).to eq(Blinkist::Airbrake::Scrubber::FILTERED)
+      expect(notice[:params][:email]).to eq(Blinkist::AirbrakeScrubber::FILTERED)
     end
 
     it "scrubs the deep-nested email from the params hash" do
@@ -33,8 +33,8 @@ describe Blinkist::Airbrake::Scrubber::ParamsEmail do
       )
 
       notifier.instance_variable_get(:@filter_chain).refine(notice)
-      expect(notice[:params][:email]).to eq(Blinkist::Airbrake::Scrubber::FILTERED)
-      expect(notice[:params][:deeply][:nested][:email]).to eq(Blinkist::Airbrake::Scrubber::FILTERED)
+      expect(notice[:params][:email]).to eq(Blinkist::AirbrakeScrubber::FILTERED)
+      expect(notice[:params][:deeply][:nested][:email]).to eq(Blinkist::AirbrakeScrubber::FILTERED)
     end
   end
 

--- a/spec/specs/lib/blinkist-airbrake-scrubber/scrubbers/params_password_spec.rb
+++ b/spec/specs/lib/blinkist-airbrake-scrubber/scrubbers/params_password_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Blinkist::Airbrake::Scrubber::ParamsPassword do
+describe Blinkist::AirbrakeScrubber::ParamsPassword do
   let(:notifier) { Airbrake[:default] }
   let(:notice) {
     Airbrake[:default].build_notice(
@@ -23,7 +23,7 @@ describe Blinkist::Airbrake::Scrubber::ParamsPassword do
 
     it "scrubs the password from the params hash" do
       notifier.instance_variable_get(:@filter_chain).refine(notice)
-      expect(notice[:params][:password]).to eq(Blinkist::Airbrake::Scrubber::FILTERED)
+      expect(notice[:params][:password]).to eq(Blinkist::AirbrakeScrubber::FILTERED)
     end
 
     it "scrubs the deep-nested password from the params hash" do
@@ -33,8 +33,8 @@ describe Blinkist::Airbrake::Scrubber::ParamsPassword do
       )
 
       notifier.instance_variable_get(:@filter_chain).refine(notice)
-      expect(notice[:params][:password]).to eq(Blinkist::Airbrake::Scrubber::FILTERED)
-      expect(notice[:params][:deeply][:nested][:password]).to eq(Blinkist::Airbrake::Scrubber::FILTERED)
+      expect(notice[:params][:password]).to eq(Blinkist::AirbrakeScrubber::FILTERED)
+      expect(notice[:params][:deeply][:nested][:password]).to eq(Blinkist::AirbrakeScrubber::FILTERED)
     end
   end
 

--- a/spec/specs/lib/blinkist_airbrake_scrubber_spec.rb
+++ b/spec/specs/lib/blinkist_airbrake_scrubber_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'securerandom'
 require 'blinkist-airbrake-scrubber'
 
-describe Blinkist::Airbrake::Scrubber do
+describe Blinkist::AirbrakeScrubber do
   let(:instantiate_airbrake) {
     Airbrake.configure :"notifier_#{ SecureRandom.uuid }" do |c|
       c.project_id  = 1
@@ -12,19 +12,19 @@ describe Blinkist::Airbrake::Scrubber do
 
   describe "Constants" do
     it "has FILTERED constant" do
-      expect(Blinkist::Airbrake::Scrubber.constants).to include(:FILTERED)
+      expect(Blinkist::AirbrakeScrubber.constants).to include(:FILTERED)
     end
 
     it "has explicit FILTERED constant content" do
-      expect(Blinkist::Airbrake::Scrubber::FILTERED).to eq('[Filtered]')
+      expect(Blinkist::AirbrakeScrubber::FILTERED).to eq('[Filtered]')
     end
 
     it "has SCRUBBERS constant" do
-      expect(Blinkist::Airbrake::Scrubber.constants).to include(:SCRUBBERS)
+      expect(Blinkist::AirbrakeScrubber.constants).to include(:SCRUBBERS)
     end
 
     it "has list of scrubbers in SCRUBBERS" do
-      expect(Blinkist::Airbrake::Scrubber::SCRUBBERS.is_a?(Array)).to be true
+      expect(Blinkist::AirbrakeScrubber::SCRUBBERS.is_a?(Array)).to be true
     end
   end
 
@@ -34,15 +34,15 @@ describe Blinkist::Airbrake::Scrubber do
       instantiate_airbrake
     end
 
-    it "calls Blinkist::Airbrake::Scrubber.run!" do
-      expect(Blinkist::Airbrake::Scrubber).to receive(:run!)
+    it "calls Blinkist::AirbrakeScrubber.run!" do
+      expect(Blinkist::AirbrakeScrubber).to receive(:run!)
       instantiate_airbrake
     end
   end
 
   describe "self.run!" do
     it "runs ::scrub! for every scrubber declared in SCRUBBERS" do
-      Blinkist::Airbrake::Scrubber::SCRUBBERS.each do |scrubber|
+      Blinkist::AirbrakeScrubber::SCRUBBERS.each do |scrubber|
         expect(scrubber).to receive(:scrub!)
       end
       instantiate_airbrake

--- a/spec/specs/version_spec.rb
+++ b/spec/specs/version_spec.rb
@@ -2,16 +2,16 @@
 require 'spec_helper'
 require 'blinkist-airbrake-scrubber/version'
 
-describe Blinkist::Airbrake::Scrubber::VERSION do
+describe Blinkist::AirbrakeScrubber::VERSION do
 
   it 'provides the current version' do
-    version = Blinkist::Airbrake::Scrubber::VERSION
+    version = Blinkist::AirbrakeScrubber::VERSION
     expect(version).to_not be nil
     expect(version.instance_of?(String)).to be true
   end
 
   it 'equals 2.1.2 for auto-check purposes' do
-    version = Blinkist::Airbrake::Scrubber::VERSION
+    version = Blinkist::AirbrakeScrubber::VERSION
     expect(version).to eq '2.1.2'
   end
 


### PR DESCRIPTION
Changed the class name across the whole gem. It should not change anything for the end users, only the version will be bumped to 3.0.0