### PR TITLE
Support airbrake 10

### DIFF
--- a/blinkist-airbrake-scrubber.gemspec
+++ b/blinkist-airbrake-scrubber.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
 
   # Airbrake
-  gem.add_dependency "airbrake", "~> 9"
+  gem.add_dependency "airbrake", ">= 9", "< 11"
 
   gem.files         = Dir["{lib,spec}/**/*", "README.md", "Rakefile", "Gemfile", "*.gemspec"]
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/lib/blinkist-airbrake-scrubber/version.rb
+++ b/lib/blinkist-airbrake-scrubber/version.rb
@@ -1,7 +1,7 @@
 module Blinkist
   module AirbrakeScrubber
 
-    VERSION = "4.1.1"
+    VERSION = "4.2.0"
 
   end
 end

--- a/spec/specs/version_spec.rb
+++ b/spec/specs/version_spec.rb
@@ -10,9 +10,9 @@ describe Blinkist::AirbrakeScrubber::VERSION do
     expect(version.instance_of?(String)).to be true
   end
 
-  it 'equals 4.0.1 for auto-check purposes' do
+  it 'equals 4.2.0 for auto-check purposes' do
     version = Blinkist::AirbrakeScrubber::VERSION
-    expect(version).to eq '4.1.1'
+    expect(version).to eq '4.2.0'
   end
 
 end


### PR DESCRIPTION
This PR adds support for Airbrake 10. This is required since with Airbrake 9 we generate a lot of spammy log messages like:

```
/root/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/airbrake-ruby-4.11.1/lib/airbrake-ruby.rb:369: warning: :start_time and :end_time are deprecated. Use :timing & :time instead
```

This issue was described here https://github.com/airbrake/airbrake-ruby/issues/532 and fixed with Airbrake 10. 

This gem here binds our airbrake version for all our projects as it seems - incl Web were we have the issues.

I propose to bump this lib to `4.2.0`. So far the change from Airbrake 9 to 10 seems to eb non-breaking for us but further testing on staging has to be done.

Full [airbrake changelog](https://github.com/airbrake/airbrake/blob/master/CHANGELOG.md).